### PR TITLE
Remove 'sectioned' from Card component

### DIFF
--- a/components/ResourceList.js
+++ b/components/ResourceList.js
@@ -67,7 +67,7 @@ class ResourceListWithProducts extends React.Component {
           if (error) return <div>{error.message}</div>;
           console.log(data);
           return (
-            <Card sectioned>
+            <Card>
               <ResourceList
                 showHeader
                 resourceName={{ singular: 'Product', plural: 'Products' }}


### PR DESCRIPTION
This PR removes 'sectioned' from the `Card` component in the `ResourceList` as it was adding extra padding inside the card