### PR TITLE
Fix issue with undefined apiVersion in registerWebhook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1264,9 +1264,9 @@
       }
     },
     "@shopify/koa-shopify-webhooks": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@shopify/koa-shopify-webhooks/-/koa-shopify-webhooks-1.1.13.tgz",
-      "integrity": "sha512-MzqWiEb3aNXG0eVBGClgguvZxgRYcCt7f6gdXVO9ERFICR9cUYq8VM5+oZmBR8eJG0iy+9/PyKsYXNYkP9kGDw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@shopify/koa-shopify-webhooks/-/koa-shopify-webhooks-2.1.0.tgz",
+      "integrity": "sha512-veKscUramImaueMWRJCpHRwQuQzdSGk8RWo1ZHFzZrzXZxC1v2lxYoB6y/Y6NCJV98x/ab3fYZVgNeechLkr/w==",
       "requires": {
         "@shopify/network": "^1.4.2",
         "koa-bodyparser": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@shopify/app-bridge-react": "^1.6.8",
     "@shopify/koa-shopify-auth": "^3.1.41",
     "@shopify/koa-shopify-graphql-proxy": "^3.1.2",
-    "@shopify/koa-shopify-webhooks": "^1.1.13",
+    "@shopify/koa-shopify-webhooks": "^2.1.0",
     "@shopify/polaris": "^3.21.1",
     "@zeit/next-css": "^1.0.1",
     "apollo-boost": "^0.3.1",

--- a/server.js
+++ b/server.js
@@ -21,6 +21,7 @@ const {
   SHOPIFY_API_SECRET_KEY,
   SHOPIFY_API_KEY,
   HOST,
+  API_VERSION
 } = process.env;
 
 app.prepare().then(() => {
@@ -43,6 +44,7 @@ app.prepare().then(() => {
           topic: 'PRODUCTS_CREATE',
           accessToken,
           shop,
+          apiVersion: API_VERSION
         });
 
         if (registration.success) {


### PR DESCRIPTION
I'm not sure how to match this PR with the issue that I created for it. This is my first PR on a project that I don't own. Anyways, I updated @shopify/koa-shopify-webhooks to 2.1.0 and added the apiVersion key-value pair to the registerWebhook parameter object.