### PR TITLE
Declaration fix

### DIFF
--- a/pages/edit-products.js
+++ b/pages/edit-products.js
@@ -10,7 +10,6 @@ import {
   PageActions,
   TextField,
   Toast,
-  Frame,
 } from '@shopify/polaris';
 import store from 'store-js';
 import gql from 'graphql-tag';


### PR DESCRIPTION
`Frame` was declared twice

This repo exists only to provide example code for the [Build a Shopify app with Node and React](https://developers.shopify.com/tutorials/build-a-shopify-app-with-node-and-react/) tutorial. Thank you for taking the time to submit a pull request, but we are not accepting contributions at this time, and all external PRs will be closed without merging.

