### PR TITLE
Include required title prop in TitleBar component

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -11,7 +11,9 @@ class Index extends React.Component {
     const emptyState = !store.get('ids');
     return (
       <Page>
-        <TitleBar primaryAction={{
+        <TitleBar
+          title="Sample App"
+          primaryAction={{
           content: 'Select products',
           onAction: () => this.setState({ open: true }),
         }} />


### PR DESCRIPTION
## This PR: 
- Adds the required `title` prop in the TitleBar component 
- Fixes https://github.com/Shopify/shopify-dev/pull/2661 
- Relates to https://github.com/Shopify/shopify-dev/pull/2914

