### PR TITLE
Bump polaris to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1244,17 +1244,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@material-ui/react-transition-group": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/react-transition-group/-/react-transition-group-4.3.0.tgz",
-      "integrity": "sha512-CwQ0aXrlUynUTY6sh3UvKuvye1o92en20VGAs6TORnSxUYeRmkX8YeTUN3lAkGiBX1z222FxLFO36WWh6q73rQ==",
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      }
-    },
     "@shopify/app-bridge": {
       "version": "1.25.0",
       "resolved": "https://registry.npmjs.org/@shopify/app-bridge/-/app-bridge-1.25.0.tgz",
@@ -1273,17 +1262,6 @@
           "resolved": "https://registry.npmjs.org/@shopify/app-bridge/-/app-bridge-1.25.0.tgz",
           "integrity": "sha512-RZFMNkC+XQbT5vE+78ZYpuUrRK2eS7wEmUBaWuRpYNJ9YoReslj9hBGgL4cqNNR2kLCj+nIpqeye8lJTgNZtkw=="
         }
-      }
-    },
-    "@shopify/javascript-utilities": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@shopify/javascript-utilities/-/javascript-utilities-2.4.1.tgz",
-      "integrity": "sha512-CDp4nWHjVXTr+rYV5RMBs8aJ5PbXUdbz47jnKisBWa9GFwJktZFj2PxefXqfLd51KpIuQpFnA/NMvq4M5tdTlw==",
-      "requires": {
-        "@types/lodash": "^4.14.65",
-        "@types/react": "^16.0.2",
-        "lodash": "^4.17.4",
-        "lodash-decorators": "^4.3.5"
       }
     },
     "@shopify/koa-shopify-auth": {
@@ -1340,24 +1318,17 @@
       }
     },
     "@shopify/polaris": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@shopify/polaris/-/polaris-4.27.0.tgz",
-      "integrity": "sha512-mJCDjHgH/Xzif3SL6xr8GHZdyvudG48Fr0GizcDtUqHoWiUqNrVy/6P4IxyL5XC8aIs/YCsJj9bph88ADRZDiA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@shopify/polaris/-/polaris-5.0.0.tgz",
+      "integrity": "sha512-sUK6amxFLiJ77QnGbKz8oyODCVBL+SUtYMpHQoICuSH9T0IVW9SjyZ4pmv9efG1mwV5gWhweMWDR+PSW+DrDmQ==",
       "requires": {
-        "@babel/runtime": "^7.1.6",
-        "@material-ui/react-transition-group": "^4.2.0",
-        "@shopify/app-bridge": "^1.3.0",
-        "@shopify/javascript-utilities": "^2.4.1",
         "@shopify/polaris-icons": "^3.10.0",
         "@shopify/polaris-tokens": "^2.12.3",
-        "@shopify/useful-types": "^1.2.4",
-        "@types/hoist-non-react-statics": "^3.3.1",
-        "@types/react": "^16.8.15",
-        "@types/react-dom": "^16.8.4",
-        "@types/react-transition-group": "^2.0.7",
-        "hoist-non-react-statics": "^3.3.0",
+        "@types/react": "^16.9.12",
+        "@types/react-dom": "^16.9.4",
+        "@types/react-transition-group": "^4.4.0",
         "lodash": "^4.17.4",
-        "tslib": "^1.9.3"
+        "react-transition-group": "^4.4.1"
       }
     },
     "@shopify/polaris-icons": {
@@ -1379,15 +1350,6 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
           "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
         }
-      }
-    },
-    "@shopify/useful-types": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@shopify/useful-types/-/useful-types-1.3.0.tgz",
-      "integrity": "sha512-BQw5KFuDm7aAH1bPECxnC1bPyaLSmZP0ecs0XwzKtgltBHWGvgu8dpqNXvY+sDfG5tnF+79EjiytRCOsTElyIg==",
-      "requires": {
-        "@types/react": ">=16.4.0",
-        "tslib": "^1.9.3"
       }
     },
     "@types/accepts": {
@@ -1445,15 +1407,6 @@
         "@types/range-parser": "*"
       }
     },
-    "@types/hoist-non-react-statics": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-      "requires": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
-      }
-    },
     "@types/http-assert": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.1.tgz",
@@ -1490,11 +1443,6 @@
       "requires": {
         "@types/koa": "*"
       }
-    },
-    "@types/lodash": {
-      "version": "4.14.157",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.157.tgz",
-      "integrity": "sha512-Ft5BNFmv2pHDgxV5JDsndOWTRJ+56zte0ZpYLowp03tW+K+t8u8YMOzAnpuqPgzX6WO1XpDIUm7u04M8vdDiVQ=="
     },
     "@types/mime": {
       "version": "2.0.1",
@@ -1534,9 +1482,9 @@
       }
     },
     "@types/react-transition-group": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-2.9.2.tgz",
-      "integrity": "sha512-5Fv2DQNO+GpdPZcxp2x/OQG/H19A01WlmpjVD9cKvVFmoVLOZ9LvBgSWG6pSXIU4og5fgbvGPaCV5+VGkWAEHA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
+      "integrity": "sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==",
       "requires": {
         "@types/react": "*"
       }
@@ -6166,14 +6114,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
-    "lodash-decorators": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash-decorators/-/lodash-decorators-4.5.0.tgz",
-      "integrity": "sha512-isfVBBSzzXu7Z6abY/Bit5hCbM+gPhQx/DluTPAmzUPF3KRtvLLRNBgVFUxw6B8vwTMGyQFRVqbvQBli9hsXZA==",
-      "requires": {
-        "tslib": "^1.7.1"
-      }
-    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -7569,6 +7509,17 @@
         "object-is": "^1.0.1"
       }
     },
+    "react-transition-group": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      }
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -7683,9 +7634,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regenerator-transform": {
       "version": "0.14.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@shopify/koa-shopify-auth": "^3.1.65",
     "@shopify/koa-shopify-graphql-proxy": "^4.0.0",
     "@shopify/koa-shopify-webhooks": "^2.4.1",
-    "@shopify/polaris": "^4.27.0",
+    "@shopify/polaris": "^5.0.0",
     "@zeit/next-css": "^1.0.1",
     "apollo-boost": "^0.4.7",
     "dotenv": "^8.2.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -3,7 +3,7 @@ import Head from 'next/head';
 import { AppProvider } from '@shopify/polaris';
 import { Provider } from '@shopify/app-bridge-react';
 import Cookies from "js-cookie";
-import '@shopify/polaris/styles.css';
+import '@shopify/polaris/dist/styles.css';
 import translations from '@shopify/polaris/locales/en.json';
 import ApolloClient from 'apollo-boost';
 import { ApolloProvider } from 'react-apollo';


### PR DESCRIPTION
This PR updates Polaris to the recently released v5 as well as updating the CSS import path.

The tutorial docs have been updates here: https://github.com/Shopify/shopify-dev/pull/3197

I have tophatted the updated files as well as reviewed the Polaris v5 [migration guide](https://github.com/Shopify/polaris-react/blob/master/documentation/guides/migrating-from-v4-to-v5.md) and changelog nothing else appears to need updating.

cc. @BPScott 