### PR TITLE
Add App Bridge ClientRouter component to charge a fee starter files

### DIFF
--- a/components/ClientRouter.js
+++ b/components/ClientRouter.js
@@ -1,0 +1,9 @@
+import {withRouter} from 'next/router';
+import {ClientRouter as AppBridgeClientRouter} from '@shopify/app-bridge-react';
+
+function ClientRouter(props) {
+  const {router} = props;
+  return <AppBridgeClientRouter history={router} />;
+}
+
+export default withRouter(ClientRouter);

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,7 @@
 import App from 'next/app';
 import Head from 'next/head';
 import { AppProvider } from '@shopify/polaris';
+import ClientRouter from '../components/ClientRouter';
 import { Provider } from '@shopify/app-bridge-react';
 import '@shopify/polaris/styles.css';
 import Cookies from 'js-cookie';
@@ -26,6 +27,7 @@ class MyApp extends App {
           <meta charSet="utf-8" />
         </Head>
         <Provider config={config}>
+        <ClientRouter />
           <AppProvider>
             <ApolloProvider client={client}>
               <Component {...pageProps} />


### PR DESCRIPTION
This PR adds the relevant code that was added to the tutorial in [this PR](https://github.com/Shopify/shopify-dev/pull/3438)
This adds the App Bridge `ClientRouter` component to allow proper client-side rendering throughout the app.