### PR TITLE
Roll back koa-router version to working one

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5980,15 +5980,16 @@
       }
     },
     "koa-router": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-9.4.0.tgz",
-      "integrity": "sha512-RO/Y8XqSNM2J5vQeDaBI/7iRpL50C9QEudY4d3T4D1A2VMKLH0swmfjxDFPiIpVDLuNN6mVD9zBI1eFTHB6QaA==",
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-8.0.8.tgz",
+      "integrity": "sha512-2rNF2cgu/EWi/NV8GlBE5+H/QBoaof83X6Z0dULmalkbt7W610/lyP2EOLVqVrUUFfjsVWL/Ju5TVBcGJDY9XQ==",
       "requires": {
         "debug": "^4.1.1",
         "http-errors": "^1.7.3",
         "koa-compose": "^4.1.0",
         "methods": "^1.1.2",
-        "path-to-regexp": "^6.1.0"
+        "path-to-regexp": "1.x",
+        "urijs": "^1.19.2"
       },
       "dependencies": {
         "debug": {
@@ -6016,6 +6017,11 @@
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
           "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
         "koa-compose": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
@@ -6027,9 +6033,12 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "path-to-regexp": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.1.0.tgz",
-          "integrity": "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw=="
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
         },
         "setprototypeof": {
           "version": "1.2.0",
@@ -9240,6 +9249,11 @@
           "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         }
       }
+    },
+    "urijs": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.2.tgz",
+      "integrity": "sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w=="
     },
     "urix": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "isomorphic-fetch": "^2.2.1",
     "js-cookie": "^2.2.1",
     "koa": "^2.13.0",
-    "koa-router": "^9.4.0",
+    "koa-router": "^8.0.6",
     "koa-session": "^6.0.0",
     "next": "^8.1.0",
     "react": "^16.13.1",


### PR DESCRIPTION
Currently, the app won't start because we run into the following error message when building:

```
UnhandledPromiseRejectionWarning: TypeError: Unexpected MODIFIER at 0, expected END
```

This seems to be caused by the latest version of `koa-router`. Rolling back to version `^8.0.6` fixes the issue, we'll need to make sure the upstream dependency is fixed before bumping up to the latest version again.