### PR TITLE
Fix bug that returns an error when 'interval' field included on appRecurringPricingDetails

### DIFF
--- a/server/getSubscriptionUrl.js
+++ b/server/getSubscriptionUrl.js
@@ -35,7 +35,7 @@ const getSubscriptionUrl = async (ctx, accessToken, shop) => {
     }`
   });
 
-  const response = await fetch(`https://${shop}/admin/api/2019-07/graphql.json`, {
+  const response = await fetch(`https://${shop}/admin/api/2020-10/graphql.json`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
The 2019 API version returns this error when attempting to add an interval:  "InputObject 'AppRecurringPricingInput' doesn't accept argument 'interval'".

This update would prevent unnecessary confusion if developers use this tutorial/repo as a basis for app development.
As noted by others here: https://community.shopify.com/c/Shopify-APIs-SDKs/Access-denied-for-appSubscriptionCreate/td-p/724918/page/5
