### PR TITLE
Fix demo build - update package.json and css loader for new version of next

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,13 +1,12 @@
 require("dotenv").config();
-const withCSS = require('@zeit/next-css');
 const webpack = require('webpack');
 
 const apiKey = JSON.stringify(process.env.SHOPIFY_API_KEY);
 
-module.exports = withCSS({
+module.exports = {
   webpack: (config) => {
     const env = { API_KEY: apiKey };
     config.plugins.push(new webpack.DefinePlugin(env));
     return config;
   },
-});
+};

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "eslint": "^5.16.0",
     "eslint-plugin-react": "^7.22.0",
-    "eslint-plugin-shopify": "^27.0.1"
+    "eslint-plugin-shopify": "^27.0.1",
+    "webpack": "^5.19.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@shopify/koa-shopify-graphql-proxy": "^4.1.0",
     "@shopify/koa-shopify-webhooks": "^2.6.0",
     "@shopify/polaris": "^5.15.0",
-    "@zeit/next-css": "^1.0.1",
     "apollo-boost": "^0.4.9",
     "dotenv": "^8.2.0",
     "graphql": "^14.7.0",


### PR DESCRIPTION
**Clone master was not working for me**
With node -v > v14.15.1

**I have cloned your master branch then:**
1/ yarn install 
2/ add .env file 
3/ yarn dev

**And build was failing:**
Warning: Built-in CSS support is being disabled due to custom CSS configuration being detected.
See here for more info: https://err.sh/next.js/built-in-css-disabled

error - ./node_modules/@shopify/polaris/dist/styles.css
TypeError: Cannot read property 'tapAsync' of undefined

With the fix in the PR, it works well ! (+ I have added webpack since not everyone has it installed globally :) )