### PR TITLE
fix: add missing API_KEY const

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,6 +5,8 @@ import ClientRouter from '../components/ClientRouter';
 import { Provider } from '@shopify/app-bridge-react';
 import '@shopify/polaris/styles.css';
 
+const API_KEY = JSON.stringify(process.env.SHOPIFY_API_KEY);
+
 class MyApp extends App {
   render() {
     const { Component, pageProps, shopOrigin } = this.props;


### PR DESCRIPTION
This repo exists only to provide example code for the [Build a Shopify app with Node and React](https://developers.shopify.com/tutorials/build-a-shopify-app-with-node-and-react/) tutorial. Thank you for taking the time to submit a pull request, but we are not accepting contributions at this time, and all external PRs will be closed without merging.

